### PR TITLE
phys enhancements

### DIFF
--- a/Atom/src/systems/ControllerSystem.cpp
+++ b/Atom/src/systems/ControllerSystem.cpp
@@ -65,14 +65,14 @@ void ControllerSystem::update()
 			if (ae.mInputManager->isKeyTriggered(controller.UP))
 			{
 				// AUDIO EVENT
-				Event e(EventID::E_AUDIO_PLAY);
-				e.setParam<string>(EventID::P_AUDIO_PLAY_AUDIOLOC,sfxJump);
-				e.setParam<ChannelGroupTypes>(EventID::P_AUDIO_PLAY_CHANNELGROUP,ChannelGroupTypes::C_SFX);
-				e.setParam<float>(EventID::P_AUDIO_PLAY_VOLUMEDB, 0.8f);
-				ae.sendEvent(e);
+				//Event e(EventID::E_AUDIO_PLAY);
+				//e.setParam<string>(EventID::P_AUDIO_PLAY_AUDIOLOC,sfxJump);
+				//e.setParam<ChannelGroupTypes>(EventID::P_AUDIO_PLAY_CHANNELGROUP,ChannelGroupTypes::C_SFX);
+				//e.setParam<float>(EventID::P_AUDIO_PLAY_VOLUMEDB, 0.8f);
+				//ae.sendEvent(e);
 
 				if(body.velocityY == 0)
-					body.totalForceY += 180;
+					body.totalForceY += 3;
 				//ATOM_INFO("VELOCITY : {}", body.velocityX);
 			}
 

--- a/Atom/src/systems/collisions/AABBCollision.cpp
+++ b/Atom/src/systems/collisions/AABBCollision.cpp
@@ -24,8 +24,8 @@ void verticalCollision(TransformComponent& transform1, PhysicsBodyComponent& bod
 				body2.velocityX = body1.velocityX;
 			}
 
-			//upward only-> x abs
-			if (body2.velocityY < body1.velocityY)
+			//upward only-> no need abs
+			if (abs(body2.velocityY) < abs(body1.velocityY))
 			{
 				//by conversation of momentum
 				//m1v1 + m2v2 = v3(m1+m2)
@@ -34,13 +34,24 @@ void verticalCollision(TransformComponent& transform1, PhysicsBodyComponent& bod
 				body2.velocityY = body1.velocityY;
 			}
 		}
+		else
+		{
+			if (body1.velocityY > 0)
+				body1.velocityY = 0;
+		}
 	}
 	else
 	{
+		if (!body2.staticBody)
+		{
+			body1.velocityX = body2.velocityX;
+		}
+
 		//assume sticky collision
 		body1.totalForceY = 0;
 		body1.accelerationY = 0;
 		body1.velocityY = 0;
+		body1.grounded = true;
 	}
 }
 
@@ -55,8 +66,11 @@ void horizontalCollision(TransformComponent& transform1, PhysicsBodyComponent& b
 	//pushing logic
 	if (!body2.staticBody)
 	{
-		if(abs(body2.velocityX) < abs(body1.velocityX))
+		if (abs(body2.velocityX) < abs(body1.velocityX))
+		{
+			body1.velocityX = (body1.mass * body1.velocityX + body2.mass * body2.velocityX) / (body1.mass + body2.mass);
 			body2.velocityX = body1.velocityX;
+		}
 	}
 	else
 	{

--- a/level_01.json
+++ b/level_01.json
@@ -8075,7 +8075,7 @@
         "shapeType": 0
       },
       "PhysicsBodyComponent": {
-        "mass": 20.0,
+        "mass": 2.0,
         "staticBody": false
       },
       "ControllerComponent": {


### PR DESCRIPTION

@auxeon 
-fixed physics jump FPS issue
-added onJump and onGround events, need to align for the params needed. 
I think @KishoreKB2711 will use "CharacterComponent.hpp" for storing character info(small/big/double jumped or not, etc),
so we may stick to checking this one instead of the name-tag when playing the sound.

@cjmms 
-pushing logic: when a character pushes another character, now both would get slows down
-stacking logic: when one character is on top of another character, now the top one wont feel slippery when you move the bottom one
-changed the weight of the large character back to 2. It makes more sense to me if the character can jump a little bit (It feels like a bug if it doesnt jump at all). Plus, it is easier to work with the physics. 